### PR TITLE
Don't activate which-function-mode automatically

### DIFF
--- a/powershell.el
+++ b/powershell.el
@@ -725,9 +725,7 @@ Where <fcn-name> is the name of the function to which <helper string> applies.
     ;; imenu doc says these are buffer-local by default
     (setq imenu-generic-expression powershell-imenu-expression)
     (setq imenu-case-fold-search nil)
-    (imenu-add-menubar-index)
-    (when (require 'which-func nil t)
-      (which-function-mode t))))
+    (imenu-add-menubar-index)))
 
 (when (require 'speedbar nil t)
   (declare-function speedbar-add-supported-extension "speedbar")


### PR DESCRIPTION
This is wrong for a few reasons:

- I don't expect a function named `powershell-setup-imenu` to do
  anything else than setting up imenu
- This violates the convention of loading up a mode *not* changing the
  overall Emacs (editing) behaviour
- which-function-mode is a global minor mode, so this change applies not
  only in powershell buffers, but anywhere else as well