### PR TITLE
Support ps1, psm1 and psd1 file extensions

### DIFF
--- a/powershell.el
+++ b/powershell.el
@@ -80,7 +80,7 @@
 (require 'compile)
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist (cons (purecopy "\\.ps1\\'")  'powershell-mode))
+(add-to-list 'auto-mode-alist '("\\.ps[dm]?1\\'" . powershell-mode))
 
 
 ;; User Variables


### PR DESCRIPTION
The Powershell v2.0 specification mentions `.ps1`, `.psm1` and `.psd1` file extensions, all of which are for files with Powershell syntax.  I've added support for recognizing these automatically and removed the useless `purecopy` call while I was at it (it's only useful on literals in Emacs core for the dumping process and is otherwise a no-op).