### PR TITLE
powershell-location-of-exe: default to 'pwsh'

### DIFF
--- a/powershell.el
+++ b/powershell.el
@@ -787,8 +787,11 @@ that value is non-nil."
 
 ;;; Code:
 (defcustom powershell-location-of-exe
-   (or (executable-find "powershell") (executable-find "pwsh"))
-  "A string, providing the location of the powershell executable."
+   (or (executable-find "pwsh") (executable-find "powershell"))
+  "A string providing the location of the powershell executable. Since
+the newer PowerShell Core (pwsh.exe) does not replace the older Windows
+PowerShell (powershell.exe) when installed, this attempts to find the
+former first, and only if it doesn't exist, falls back to the latter."
   :group 'powershell
   :type 'string)
 


### PR DESCRIPTION
Windows PowerShell (powershell.exe) is the legacy 5.X and earlier version of PowerShell that ships with Windows. PowerShell Core (pwsh.exe) is the modern, cross-platform PowerShell that has been supported since 6.0 (January 2018) up through the most recent (December 2021) 7.2.1 release.

The current `or` as written will short-circuit on the built-in `powershell.exe`, regardless of whether `pwsh.exe` is installed. This change reverses this order so that those who have optionally installed PowerShell Core will have `M-x powershell` initiate the newer shell.