### PR TITLE
Document ability to use use-package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Then install `powershell.el`:
 
 <kbd>M-x package-install RET powershell RET</kbd>
 
+You can also install the package use `use-package`:
+
+```lisp
+(use-package powershell
+    :ensure t)
+```
+
 **El-Get**
 
 `powershell.el` is included in the El-Get repository


### PR DESCRIPTION
Emacs has since version 29 included `use-package` which makes maintaining installed packages much easier.

Document how to do this for `powershell-mode` in the readme.